### PR TITLE
Add support for multiple groups to train_udf.py and training_runner.py

### DIFF
--- a/exasol_data_science_utils_python/model_utils/udfs/training_runner.py
+++ b/exasol_data_science_utils_python/model_utils/udfs/training_runner.py
@@ -1,5 +1,5 @@
 from pathlib import PurePosixPath
-from typing import List
+from typing import List, Generator, Any, Dict
 
 import pyexasol
 
@@ -21,6 +21,8 @@ from exasol_data_science_utils_python.udf_utils.sql_executor import SQLExecutor
 
 class TrainingRunner:
     def __init__(self,
+                 job_id: str,
+                 model_id: str,
                  model_connection_object: ConnectionObject,
                  path_under_model_connection: PurePosixPath,
                  db_connection_object: ConnectionObject,
@@ -31,6 +33,8 @@ class TrainingRunner:
                  target_schema: Schema,
                  model,
                  column_preprocessor_creator: AbstractColumnPreprocessorCreator):
+        self.job_id = job_id
+        self.model_id = model_id
         self.path_under_model_connection = path_under_model_connection
         self.source_table = source_table
         self.target_schema = target_schema
@@ -46,7 +50,7 @@ class TrainingRunner:
             raise ValueError(
                 f"Not all columns in {[column.fully_qualified() for column in self.columns]} are from the same table.")
 
-    def run(self):
+    def run(self) -> Dict[str, Any]:
         bucket_fs_factory = BucketFSFactory()
         model_bucketfs_location = \
             bucket_fs_factory.create_bucketfs_location(
@@ -74,6 +78,8 @@ class TrainingRunner:
         sql_udf_stub_creator.create_combine_to_voting_regressor_udf(sql_executor, self.target_schema)
 
         self.run_train_queries(sql_executor)
+        model_info = self.get_combined_model_info(sql_executor)
+        return model_info
 
     def run_train_queries(self,
                           sql_executor: SQLExecutor):
@@ -81,19 +87,49 @@ class TrainingRunner:
         self.run_combine_to_voting_regressor_udf(sql_executor)
 
     def run_combine_to_voting_regressor_udf(self, sql_executor):
-        create_table = f"""
-        CREATE TABLE IF NOT EXISTS {self.target_schema.fully_qualified()}."FITTED_COMBINED_MODEL" (
-            session_id VARCHAR(2000000),
-            model_connection_name VARCHAR(2000000),
-            path_under_model_connection VARCHAR(2000000),
-            model_path VARCHAR(2000000)
-        )
+        self.create_fitted_combined_model_table(sql_executor)
+        self.insert_combined_model(sql_executor)
+
+    def get_combined_model_info(self, sql_executor) -> Dict[str, Any]:
+        result_query = f"""
+            SELECT 
+                job_id,
+                model_id,
+                model_connection_name,
+                path_under_model_connection,
+                model_path
+            FROM {self.target_schema.fully_qualified()}."FITTED_COMBINED_MODEL"
+            WHERE job_id = '{self.job_id}' 
+            AND model_id = '{self.model_id}'
+            AND model_connection_name = '{self.model_connection_object.name}'
+            AND (
+                path_under_model_connection = {self._get_path_under_model_connection_as_sql_value()}
+                OR (
+                    {self._get_path_under_model_connection_as_sql_value()} is null AND
+                    path_under_model_connection is null
+                )
+            )
         """
-        sql_executor.execute(create_table)
+        rs = sql_executor.execute(result_query)
+        rows = rs.fetchall()
+        if rs.rowcount() != 1:
+            raise RuntimeError(f"Internal Error: Got not exactly one model from query {result_query}")
+        row = rows[0]
+        model_info = {
+            "job_id": row[0],
+            "model_id": row[1],
+            "model_connection_name": row[2],
+            "path_under_model_connection": row[3],
+            "model_path": row[4]
+        }
+        return model_info
+
+    def insert_combined_model(self, sql_executor):
         query = f"""
             INSERT INTO {self.target_schema.fully_qualified()}."FITTED_COMBINED_MODEL"
             SELECT  
-                CURRENT_SESSION, 
+                '{self.job_id}',
+                '{self.model_id}',
                 model_connection_name, 
                 path_under_model_connection, 
                 combined_model_path
@@ -103,7 +139,8 @@ class TrainingRunner:
                     path_under_model_connection,
                     model_path) 
                 FROM {self.target_schema.fully_qualified()}."FITTED_BASE_MODELS"
-                WHERE session_id = CURRENT_SESSION
+                WHERE job_id = '{self.job_id}'
+                AND model_id = '{self.model_id}'
                 AND model_connection_name = '{self.model_connection_object.name}'
                 AND (
                     path_under_model_connection = {self._get_path_under_model_connection_as_sql_value()}
@@ -116,6 +153,18 @@ class TrainingRunner:
             """
         sql_executor.execute(query)
 
+    def create_fitted_combined_model_table(self, sql_executor):
+        create_table = f"""
+        CREATE TABLE IF NOT EXISTS {self.target_schema.fully_qualified()}."FITTED_COMBINED_MODEL" (
+            job_id VARCHAR(2000000),
+            model_id VARCHAR(2000000),
+            model_connection_name VARCHAR(2000000),
+            path_under_model_connection VARCHAR(2000000),
+            model_path VARCHAR(2000000)
+        )
+        """
+        sql_executor.execute(create_table)
+
     def _get_path_under_model_connection_as_sql_value(self):
         if self.path_under_model_connection is None:
             return "null"
@@ -127,7 +176,8 @@ class TrainingRunner:
         select_list_for_columns = self.get_select_list_for_columns(self.columns)
         create_table = f"""
         CREATE TABLE IF NOT EXISTS {self.target_schema.fully_qualified()}."FITTED_BASE_MODELS" (
-            session_id VARCHAR(2000000),
+            job_id VARCHAR(2000000),
+            model_id VARCHAR(2000000),
             model_connection_name VARCHAR(2000000),
             path_under_model_connection VARCHAR(2000000),
             model_path VARCHAR(2000000),
@@ -140,7 +190,8 @@ class TrainingRunner:
         query = f"""
             INSERT INTO {self.target_schema.fully_qualified()}."FITTED_BASE_MODELS" 
             SELECT 
-                CURRENT_SESSION, 
+                '{self.job_id}',
+                '{self.model_id}',
                 model_connection_name, 
                 path_under_model_connection, 
                 output_model_path,

--- a/tests/integration_tests/test_train_udf.py
+++ b/tests/integration_tests/test_train_udf.py
@@ -81,11 +81,13 @@ def udf_wrapper():
     from exasol_data_science_utils_python.model_utils.udfs.column_preprocessor_creator import ColumnPreprocessorCreator
     from exasol_data_science_utils_python.model_utils.udfs.train_udf import TrainUDF
 
+    train_udf = TrainUDF()
+
     def run(ctx: UDFContext):
         model = SGDRegressor(random_state=RandomState(0), loss="squared_loss", verbose=False,
                              fit_intercept=True, eta0=0.9, power_t=0.1, learning_rate='invscaling')
         column_preprocessor_creator = ColumnPreprocessorCreator()
-        TrainUDF().run(exa, ctx, model, column_preprocessor_creator)
+        train_udf.run(exa, ctx, model, column_preprocessor_creator)
 
 
 def test_train_udf_with_mock_random_partitions(
@@ -93,14 +95,21 @@ def test_train_udf_with_mock_random_partitions(
         create_input_table,
         pyexasol_connection,
         db_connection):
-    run_mock_test_valid(
-        db_connection,
-        pyexasol_connection,
-        split_by_node=False,
-        number_of_random_partitions=3,
-        split_by_columns=None,
-        expected_number_of_base_models=3,
-    )
+    expected_number_of_base_models = 3
+    result, fitted_base_models, fitted_combined_models, unique_base_models = \
+        run_mock_test_valid(
+            db_connection,
+            pyexasol_connection,
+            split_by_node=False,
+            number_of_random_partitions=3,
+            split_by_columns=None,
+        )
+    assert len(fitted_base_models) == expected_number_of_base_models
+    assert len(unique_base_models) == expected_number_of_base_models
+    assert len(fitted_combined_models) == 1
+    assert len(result) == 1
+    for group in result:
+        assert len(group.rows) == 1
 
 
 def test_train_udf_with_mock_split_by_node(
@@ -108,14 +117,21 @@ def test_train_udf_with_mock_split_by_node(
         create_input_table,
         pyexasol_connection,
         db_connection):
-    run_mock_test_valid(
-        db_connection,
-        pyexasol_connection,
-        split_by_node=True,
-        number_of_random_partitions=None,
-        split_by_columns=None,
-        expected_number_of_base_models=1,
-    )
+    expected_number_of_base_models = 1
+    result, fitted_base_models, fitted_combined_models, unique_base_models = \
+        run_mock_test_valid(
+            db_connection,
+            pyexasol_connection,
+            split_by_node=True,
+            number_of_random_partitions=None,
+            split_by_columns=None,
+        )
+    assert len(fitted_base_models) == expected_number_of_base_models
+    assert len(unique_base_models) == expected_number_of_base_models
+    assert len(fitted_combined_models) == 1
+    assert len(result) == 1
+    for group in result:
+        assert len(group.rows) == 1
 
 
 def test_train_udf_with_mock_split_by_columns(
@@ -123,14 +139,21 @@ def test_train_udf_with_mock_split_by_columns(
         create_input_table,
         pyexasol_connection,
         db_connection):
-    run_mock_test_valid(
-        db_connection,
-        pyexasol_connection,
-        split_by_node=False,
-        number_of_random_partitions=None,
-        split_by_columns="P1,P2",
-        expected_number_of_base_models=4,
-    )
+    expected_number_of_base_models = 4
+    result, fitted_base_models, fitted_combined_models, unique_base_models = \
+        run_mock_test_valid(
+            db_connection,
+            pyexasol_connection,
+            split_by_node=False,
+            number_of_random_partitions=None,
+            split_by_columns="P1,P2",
+        )
+    assert len(fitted_base_models) == expected_number_of_base_models
+    assert len(unique_base_models) == expected_number_of_base_models
+    assert len(fitted_combined_models) == 1
+    assert len(result) == 1
+    for group in result:
+        assert len(group.rows) == 1
 
 
 def test_train_udf_with_mock_random_partitions_and_split_by_columns(
@@ -138,14 +161,21 @@ def test_train_udf_with_mock_random_partitions_and_split_by_columns(
         create_input_table,
         pyexasol_connection,
         db_connection):
-    run_mock_test_valid(
-        db_connection,
-        pyexasol_connection,
-        split_by_node=False,
-        number_of_random_partitions=3,
-        split_by_columns="P1",
-        expected_number_of_base_models=6,
-    )
+    expected_number_of_base_models = 6
+    result, fitted_base_models, fitted_combined_models, unique_base_models = \
+        run_mock_test_valid(
+            db_connection,
+            pyexasol_connection,
+            split_by_node=False,
+            number_of_random_partitions=3,
+            split_by_columns="P1",
+        )
+    assert len(fitted_base_models) == expected_number_of_base_models
+    assert len(unique_base_models) == expected_number_of_base_models
+    assert len(fitted_combined_models) == 1
+    assert len(result) == 1
+    for group in result:
+        assert len(group.rows) == 1
 
 
 def test_train_udf_with_mock_split_by_node_and_random_partitions(
@@ -153,14 +183,21 @@ def test_train_udf_with_mock_split_by_node_and_random_partitions(
         create_input_table,
         pyexasol_connection,
         db_connection):
-    run_mock_test_valid(
-        db_connection,
-        pyexasol_connection,
-        split_by_node=True,
-        number_of_random_partitions=2,
-        split_by_columns=None,
-        expected_number_of_base_models=2,
-    )
+    expected_number_of_base_models = 2
+    result, fitted_base_models, fitted_combined_models, unique_base_models = \
+        run_mock_test_valid(
+            db_connection,
+            pyexasol_connection,
+            split_by_node=True,
+            number_of_random_partitions=2,
+            split_by_columns=None
+        )
+    assert len(fitted_base_models) == expected_number_of_base_models
+    assert len(unique_base_models) == expected_number_of_base_models
+    assert len(fitted_combined_models) == 1
+    assert len(result) == 1
+    for group in result:
+        assert len(group.rows) == 1
 
 
 def test_train_udf_with_mock_split_by_columns_empty_string(
@@ -168,14 +205,47 @@ def test_train_udf_with_mock_split_by_columns_empty_string(
         create_input_table,
         pyexasol_connection,
         db_connection):
-    run_mock_test_valid(
-        db_connection,
+    expected_number_of_base_models = 2
+    result, fitted_base_models, fitted_combined_models, unique_base_models = \
+        run_mock_test_valid(
+            db_connection,
+            pyexasol_connection,
+            split_by_node=False,
+            number_of_random_partitions=2,
+            split_by_columns="",
+        )
+    assert len(fitted_base_models) == expected_number_of_base_models
+    assert len(unique_base_models) == expected_number_of_base_models
+    assert len(fitted_combined_models) == 1
+    assert len(result) == 1
+    for group in result:
+        assert len(group.rows) == 1
+
+
+def test_train_udf_with_mock_multiple_groups(
+        upload_language_container,
+        create_input_table,
         pyexasol_connection,
-        split_by_node=False,
-        number_of_random_partitions=2,
-        split_by_columns="",
-        expected_number_of_base_models=2,
-    )
+        db_connection):
+    number_of_groups = 2
+    expected_number_of_base_models = 2
+    result, fitted_base_models, fitted_combined_models, unique_base_models = \
+        run_mock_test_valid(
+            db_connection,
+            pyexasol_connection,
+            split_by_node=False,
+            number_of_random_partitions=2,
+            split_by_columns="",
+            number_of_groups=number_of_groups
+        )
+    unique_model_id_in_base_models = {row[1] for row in fitted_base_models}
+    assert len(fitted_base_models) == expected_number_of_base_models * number_of_groups
+    assert len(unique_model_id_in_base_models) == number_of_groups
+    assert len(unique_base_models) == expected_number_of_base_models * number_of_groups
+    assert len(fitted_combined_models) == 1 * number_of_groups
+    assert len(result) == number_of_groups
+    for group in result:
+        assert len(group.rows) == 1
 
 
 def run_mock_test_valid(db_connection,
@@ -183,28 +253,35 @@ def run_mock_test_valid(db_connection,
                         split_by_node: bool,
                         number_of_random_partitions: int,
                         split_by_columns: str,
-                        expected_number_of_base_models: int):
-    run_mock_test(db_connection,
-                  pyexasol_connection,
-                  split_by_node,
-                  number_of_random_partitions,
-                  split_by_columns)
+                        number_of_groups: int = 1):
+    result = run_mock_test(db_connection,
+                           pyexasol_connection,
+                           split_by_node,
+                           number_of_random_partitions,
+                           split_by_columns,
+                           number_of_groups)
+    fitted_base_models, fitted_combined_models, unique_base_models = get_results(pyexasol_connection, result)
+    return result, fitted_base_models, fitted_combined_models, unique_base_models
+
+
+def get_results(pyexasol_connection, result):
     fitted_base_models = pyexasol_connection.execute("""
         SELECT * FROM TARGET_SCHEMA.FITTED_BASE_MODELS""").fetchall()
-    print(fitted_base_models)
-    assert len(fitted_base_models) == expected_number_of_base_models
-    assert len({row[3] for row in fitted_base_models}) == expected_number_of_base_models
+    print("fitted_base_models", fitted_base_models)
     fitted_combined_models = pyexasol_connection.execute("""
         SELECT * FROM TARGET_SCHEMA.FITTED_COMBINED_MODEL""").fetchall()
-    print(fitted_combined_models)
-    assert len(fitted_combined_models) == 1
+    print("fitted_combined_models", fitted_combined_models)
+    unique_base_models = {row[4] for row in fitted_base_models}
+    print("result", result)
+    return fitted_base_models, fitted_combined_models, unique_base_models
 
 
 def run_mock_test(db_connection,
                   pyexasol_connection,
                   split_by_node: bool,
                   number_of_random_partitions: int,
-                  split_by_columns: str):
+                  split_by_columns: str,
+                  number_of_groups: int = 1):
     executor = UDFMockExecutor()
     meta = MockMetaData(
         script_code_wrapper_function=udf_wrapper,
@@ -227,7 +304,11 @@ def run_mock_test(db_connection,
         ],
         output_type="EMIT",
         output_columns=[
-            Column("output_model_path", str, "VARCHAR(2000000)"),
+            Column("job_id", str, "VARCHAR(2000000)"),
+            Column("model_id", str, "VARCHAR(2000000)"),
+            Column("model_connection_name", str, "VARCHAR(2000000)"),
+            Column("path_under_model_connection", str, "VARCHAR(2000000)"),
+            Column("model_path", str, "VARCHAR(2000000)"),
         ]
     )
     model_connection, model_connection_name = \
@@ -238,26 +319,25 @@ def run_mock_test(db_connection,
                                  "MODEL_CONNECTION": model_connection,
                                  "DB_CONNECTION": db_connection
                              })
-    input_data = []
-    input_data.append(
-        (
-            model_connection_name,
-            "my_path_under_model_connection",
-            "DB_CONNECTION",
-            "TEST",
-            "ABC",
-            "A,B",
-            "C",
-            "TARGET_SCHEMA",
-            10,
-            100,
-            10000,
-            split_by_node,
-            number_of_random_partitions,
-            split_by_columns
-        )
-    )
-    result = list(executor.run([Group(input_data)], exa))
+
+    groups = [Group([(
+        model_connection_name,
+        "my_path_under_model_connection_" + str(i),
+        "DB_CONNECTION",
+        "TEST",
+        "ABC",
+        "A,B",
+        "C",
+        "TARGET_SCHEMA",
+        10,
+        100,
+        10000,
+        split_by_node,
+        number_of_random_partitions,
+        split_by_columns
+    )]) for i in range(number_of_groups)]
+    result = list(executor.run(groups, exa))
+    return result
 
 
 def test_train_udf(
@@ -288,17 +368,25 @@ def test_train_udf(
         number_of_random_partitions INTEGER,
         split_by_columns VARCHAR(2000000)
     ) 
-    EMITS (o varchar(10000)) AS
+    EMITS (
+        job_id VARCHAR(2000000),
+        model_id VARCHAR(2000000),
+        model_connection_name VARCHAR(2000000),
+        path_under_model_connection VARCHAR(2000000),
+        model_path VARCHAR(2000000)
+    ) AS
     from sklearn.linear_model import SGDRegressor
     from numpy.random import RandomState
     from exasol_data_science_utils_python.model_utils.udfs.column_preprocessor_creator import ColumnPreprocessorCreator
     from exasol_data_science_utils_python.model_utils.udfs.train_udf import TrainUDF
 
+    train_udf = TrainUDF()
+
     def run(ctx):
         model = SGDRegressor(random_state=RandomState(0), loss="squared_loss", verbose=False,
                              fit_intercept=True, eta0=0.9, power_t=0.1, learning_rate='invscaling')
         column_preprocessor_creator = ColumnPreprocessorCreator()
-        TrainUDF().run(exa, ctx, model, column_preprocessor_creator)
+        train_udf.run(exa, ctx, model, column_preprocessor_creator)
     """)
     pyexasol_connection.execute(udf_sql)
     query_udf = f"""


### PR DESCRIPTION
- Models are now stored and identified with job id and model ids

Closes #25 